### PR TITLE
Solve issue 30 

### DIFF
--- a/app/features/quizzify/tools.py
+++ b/app/features/quizzify/tools.py
@@ -25,19 +25,19 @@ relative_path = "features/quzzify"
 
 logger = setup_logger(__name__)
 
-def transform_json_dict(input_data: dict):
-    # Check if each choice has 'key' and 'value'
-    for choice in input_data.get("choices", []):
-        if "key" not in choice or "value" not in choice:
-            # Print a message and return the original dictionary if any choice does not have 'key' and 'value'
-            return input_data
+def transform_json_dict(input_data: dict) -> dict:
+    # Validate and parse the input data to ensure it matches the QuizQuestion schema
+    quiz_question = QuizQuestion(**input_data)
+    
+    # Transform the choices list into a dictionary
+    transformed_choices = {choice.key: choice.value for choice in quiz_question.choices}
     
     # Create the transformed structure
     transformed_data = {
-        "question": input_data["question"],
-        "choices": {choice["key"]: choice["value"] for choice in input_data["choices"]},
-        "answer": input_data["answer"],
-        "explanation": input_data["explanation"]
+        "question": quiz_question.question,
+        "choices": transformed_choices,
+        "answer": quiz_question.answer,
+        "explanation": quiz_question.explanation
     }
     
     return transformed_data
@@ -367,8 +367,17 @@ class QuizBuilder:
 class QuestionChoice(BaseModel):
     key: str = Field(description="A unique identifier for the choice using letters A, B, C, D, etc.")
     value: str = Field(description="The text content of the choice")
+
 class QuizQuestion(BaseModel):
-    question: str = Field(description="The question text")
-    choices: List[QuestionChoice] = Field(description="A list of choices")
-    answer: str = Field(description="The correct answer")
-    explanation: str = Field(description="An explanation of why the answer is correct")
+    question: str = Field(
+        description="The question text. Example: 'If the regression equation is given as People.Phys. = 1650 + 21.3 People.Tel., where, People.Phys. represents the number of people per physician and People.Tel. represents the number of people per television set, what impact will removing an outlier with high People.Tel. and high People.Phys. values have on the slope of the regression line?'"
+    )
+    choices: List[QuestionChoice] = Field(
+        description="A list of choices for the question. Example: [{ 'key': 'A', 'value': 'The slope of the regression line will increase.' }, { 'key': 'B', 'value': 'The slope of the regression line will decrease.' }, { 'key': 'C', 'value': 'The slope of the regression line will remain the same.' }, { 'key': 'D', 'value': 'It is not possible to determine the impact on the slope without additional information.' }]"
+    )
+    answer: str = Field(
+        description="The correct answer key corresponding to one of the choices. Example: 'B'"
+    )
+    explanation: str = Field(
+        description="An explanation of why the answer is correct. Example: 'Since the outlier has high values for both, People.Tel. and People.Phys., removing it will bring the remaining data points closer together, resulting in a steeper slope. If the outlier were only high in People.Tel. but not in People.Phys., then it would have less impact on the slope.'"
+    )

--- a/app/features/quizzify/tools.py
+++ b/app/features/quizzify/tools.py
@@ -25,6 +25,23 @@ relative_path = "features/quzzify"
 
 logger = setup_logger(__name__)
 
+def transform_json_dict(input_data: dict):
+    # Check if each choice has 'key' and 'value'
+    for choice in input_data.get("choices", []):
+        if "key" not in choice or "value" not in choice:
+            # Print a message and return the original dictionary if any choice does not have 'key' and 'value'
+            return input_data
+    
+    # Create the transformed structure
+    transformed_data = {
+        "question": input_data["question"],
+        "choices": {choice["key"]: choice["value"] for choice in input_data["choices"]},
+        "answer": input_data["answer"],
+        "explanation": input_data["explanation"]
+    }
+    
+    return transformed_data
+
 def read_text_file(file_path):
     # Get the directory containing the script file
     script_dir = os.path.dirname(os.path.abspath(__file__))
@@ -317,9 +334,12 @@ class QuizBuilder:
 
         while len(generated_questions) < num_questions and attempts < max_attempts:
             response = chain.invoke(self.topic)
+
+            response = transform_json_dict(response)
+
             if self.verbose:
                 logger.info(f"Generated response attempt {attempts + 1}: {response}")
-            
+
             # Directly check if the response format is valid
             if self.validate_response(response):
                 response["choices"] = self.format_choices(response["choices"])


### PR DESCRIPTION
This Pull Request is done for solving #30. 
As @mikhailocampo mentioned, I had to monitor the LLM responses in order to evaluate the problem. What I have discovered was that the actual problem was not the ```json string, but indeed it was this specific response format that was not appropriately managed by the validate_response function:
![image](https://github.com/radicalxdev/kai-ai-backend/assets/113047749/a7b10f2b-8339-4fd5-8656-1d71a2a8dcac)
As you can see, the format changes for the choices, organizing them differently as how it is normally accepted:
![image](https://github.com/radicalxdev/kai-ai-backend/assets/113047749/602af053-325e-44f4-a6f6-28f77ee8f68d)
For that reason, I have implemented a function to pre-process the provided dict from the chain. As a result, we can decrease the latency for performing less requests, decreasing the token costs and achieving the requested amount of questions. 
This was the result of requesting 3 questions (With multiple attempts as a result of the unaccepted format) before of the implementation of the function:
![image](https://github.com/radicalxdev/kai-ai-backend/assets/113047749/d257a810-c4e3-461c-b9c0-06d5c0e3b87c)
And this is the result of requesting 3 questions after implementing the function:
![image](https://github.com/radicalxdev/kai-ai-backend/assets/113047749/9d60419c-c693-4d0c-a856-1413b36530c3)
