### PR TITLE
Edit README and Dockerfile for Improved Reproducibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,6 @@ COPY ./app /app
 
 ENV GOOGLE_APPLICATION_CREDENTIALS=/app/local-auth.json 
 ENV ENV_TYPE="dev"
-ENV PROJECT_ID="kai-ai-f63c8"
+ENV PROJECT_ID="Enter your project ID here"
 
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -94,17 +94,18 @@ pip install -r requirements.txt
 1. Open your command line interface.
 2. Set the path to the JSON key file by running:
    ```bash
-   set GOOGLE_APPLICATION_CREDENTIALS=/app/local-auth.json```
+   set GOOGLE_APPLICATION_CREDENTIALS=/app/local-auth.json
+   ```
 ## Set the environment type and project ID:
 
 
 ```bash
-  set ENV_TYPE="dev"
-  set PROJECT_ID="Enter your project ID here"
+set ENV_TYPE="dev"
+set PROJECT_ID="Enter your project ID here"
 ```
 
 ```bash
-  uvicorn main:app --reload
+uvicorn main:app --reload
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,6 @@ The Docker container uses several key environment variables:
 You can access the backend by visiting:
 ```Bash
 http://localhost:8000
-
 ```
 
 After your container starts, you should see the FastAPI landing page, indicating that the application is running successfully.

--- a/README.md
+++ b/README.md
@@ -154,7 +154,11 @@ The Docker container uses several key environment variables:
 `LANGCHAIN_ENDPOINT`
 `LANGCHAIN_API_KEY`
 `LANGCHAIN_PROJECT`
-- Ensure these variables are correctly configured in your Dockerfile or passed as additional parameters to your Docker run command if needed.
+- Ensure these variables are correctly configured in your Dockerfile or passed as additional parameters to your Docker run command, as shown in the example below:
+  ```bash
+  docker run --env ENV_TYPE=dev --env="Enter your project ID here" -p 8000:8000 kai-backend:latest 
+  ```
+
 ## Accessing the Application
 You can access the backend by visiting:
 ```Bash


### PR DESCRIPTION
After running Kai locally, I suggest the following adjustments to these files to facilitate code reproduction for future users:

- Remove blank spaces from bash commands to make them easier to copy and paste.
- Change "ProjectID" in the Dockerfile to "Enter your project ID here" to clearly indicate that the user needs to modify this line.
- Include examples of how to pass environment variables when running the container.