### PR TITLE
Solve Issue #23 - Dynamo

### DIFF
--- a/app/features/dynamo/tools.py
+++ b/app/features/dynamo/tools.py
@@ -44,8 +44,8 @@ def summarize_transcript(youtube_url: str, max_video_length=600, verbose=False) 
         raise VideoTranscriptError(f"No video transcripts available", youtube_url) from e
     
     splitter = RecursiveCharacterTextSplitter(
-        chunk_size = 1000,
-        chunk_overlap = 0
+        chunk_size = 2000 if length > 300 else 1000,
+        chunk_overlap = 100 if length > 300 else 0,
     )
     
     split_docs = splitter.split_documents(docs)
@@ -56,8 +56,9 @@ def summarize_transcript(youtube_url: str, max_video_length=600, verbose=False) 
     if verbose:
         logger.info(f"Found video with title: {title} and length: {length}")
         logger.info(f"Splitting documents into {len(split_docs)} chunks")
-    
+
     chain = load_summarize_chain(model, chain_type='map_reduce')
+
     response = chain.invoke(split_docs)
     
     if response and verbose: logger.info("Successfully completed generating summary")


### PR DESCRIPTION
This PR is made for analyzing and implementing a new approach for solving Issue #23 related to Dynamo.
When I started using the system, I tested this 9-minutes video: https://www.youtube.com/watch?v=rWcG-p1oQe0 and I received the Quota Exceeded error after retrying it for 5 attempts:
![image](https://github.com/radicalxdev/kai-ai-backend/assets/113047749/638c820f-bb6f-491a-88ff-8ed51b6a4bff)
As a result, I tested another video that has a duration of 1 minute: https://www.youtube.com/watch?v=1aA1WGON49E, and it worked with the actual approach.
For that reason, what I've done is to refactor the **chunk_size** and **chunk_overlap** for managing appropriately it in base of the length of the video, considering the threshold of 3 minutes for it: 
![image](https://github.com/radicalxdev/kai-ai-backend/assets/113047749/40386e74-63d8-40a8-a62c-d3bbe97e1157)
Then, I've tested both videos and they worked appropriately. 
![image](https://github.com/radicalxdev/kai-ai-backend/assets/113047749/1800c6eb-2889-45b2-9a31-41f86a1ee7db)
I also used this 5-minutes video: https://www.youtube.com/watch?v=iDbdXTMnOmE, and it also worked.
Indeed, I've tested it 4 times and the parser hasn't failed in any of those attempts. 
![image](https://github.com/radicalxdev/kai-ai-backend/assets/113047749/4a8ef412-8477-4233-abae-791703a27cc2)
What I've discovered is that the long latency is caused by the `summarize_transcript` method, specially if the video has an extense duration (9 to 10 minutes). 
For now, we can be working in this way. But I suggest to optimize the `summarize_transcript` method in base of how we manage `load_summarize_chain` because the latency is produced by this.