### PR TITLE
Resolve module import errors and improve docker caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 # backend/Dockerfile
 FROM python:3.10.12
 
-WORKDIR /app
+WORKDIR /code
 
-COPY app/ /app
+COPY app/requirements.txt /code/requirements.txt
 
-RUN pip install --no-cache-dir -r /app/requirements.txt
+RUN pip install --no-cache-dir -r /code/requirements.txt
 
-COPY ./app /app
+COPY ./app /code/app
 
 # Local development key set
 # ENV TYPES: dev, production
@@ -16,6 +16,6 @@ COPY ./app /app
 
 ENV GOOGLE_APPLICATION_CREDENTIALS=/app/local-auth.json 
 ENV ENV_TYPE="dev"
-ENV PROJECT_ID="Enter your project ID here"
+ENV PROJECT_ID="kai-ai-f63c8"
 
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["fastapi", "run", "app/main.py", "--port", "8000"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,6 @@ COPY ./app /code/app
 # When set to dev, API Key on endpoint requests are just 'dev'
 # When set to production, API Key on endpoint requests are the actual API Key
 
-ENV GOOGLE_APPLICATION_CREDENTIALS=/app/local-auth.json 
-ENV ENV_TYPE="dev"
-ENV PROJECT_ID="kai-ai-f63c8"
+ENV PYTHONPATH=/code/app
 
 CMD ["fastapi", "run", "app/main.py", "--port", "8000"]

--- a/app/api/router.py
+++ b/app/api/router.py
@@ -2,11 +2,11 @@ from fastapi import APIRouter, Depends, HTTPException
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
 from typing import Union
-from services.schemas import ToolRequest, ChatRequest, Message, ChatResponse, ToolResponse
-from utils.auth import key_check
-from services.logger import setup_logger
-from api.error_utilities import InputValidationError, ErrorResponse
-from api.tool_utilities import load_tool_metadata, execute_tool, finalize_inputs
+from app.services.schemas import ToolRequest, ChatRequest, Message, ChatResponse, ToolResponse
+from app.utils.auth import key_check
+from app.services.logger import setup_logger
+from app.api.error_utilities import InputValidationError, ErrorResponse
+from app.api.tool_utilities import load_tool_metadata, execute_tool, finalize_inputs
 
 logger = setup_logger(__name__)
 router = APIRouter()
@@ -46,7 +46,7 @@ async def submit_tool( data: ToolRequest, _ = Depends(key_check)):
 
 @router.post("/chat", response_model=ChatResponse)
 async def chat( request: ChatRequest, _ = Depends(key_check) ):
-    from features.Kaichat.core import executor as kaichat_executor
+    from app.features.Kaichat.core import executor as kaichat_executor
     
     user_name = request.user.fullName
     chat_messages = request.messages

--- a/app/api/tests/test_tool_utility.py
+++ b/app/api/tests/test_tool_utility.py
@@ -1,9 +1,9 @@
 import json
 import pytest
 from unittest.mock import patch, MagicMock, mock_open
-from services.tool_registry import BaseTool, ToolInput, ToolFile
+from app.services.tool_registry import BaseTool, ToolInput, ToolFile
 from fastapi import HTTPException
-from api.tool_utilities import get_executor_by_name, load_tool_metadata, prepare_input_data, execute_tool
+from app.api.tool_utilities import get_executor_by_name, load_tool_metadata, prepare_input_data, execute_tool
 
 # Sample configuration for tools_config
 tools_config = {

--- a/app/api/tests/test_tools.py
+++ b/app/api/tests/test_tools.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 from main import app  
-from services.tool_registry import validate_inputs
+from app.services.tool_registry import validate_inputs
 import pytest
 import os
 

--- a/app/api/tool_utilities.py
+++ b/app/api/tool_utilities.py
@@ -1,8 +1,8 @@
 import json
 import os
-from services.logger import setup_logger
-from services.tool_registry import ToolFile
-from api.error_utilities import VideoTranscriptError, InputValidationError, ToolExecutorError
+from app.services.logger import setup_logger
+from app.services.tool_registry import ToolFile
+from app.api.error_utilities import VideoTranscriptError, InputValidationError, ToolExecutorError
 from typing import Dict, Any, List
 from fastapi import HTTPException
 from pydantic import ValidationError

--- a/app/features/Kaichat/core.py
+++ b/app/features/Kaichat/core.py
@@ -1,6 +1,6 @@
 from langchain_google_genai import GoogleGenerativeAI
 from langchain.prompts import PromptTemplate
-from services.schemas import ChatMessage, Message
+from app.services.schemas import ChatMessage, Message
 import os
 
 def read_text_file(file_path):

--- a/app/features/dynamo/core.py
+++ b/app/features/dynamo/core.py
@@ -1,6 +1,6 @@
-from features.dynamo.tools import summarize_transcript, generate_flashcards
-from services.logger import setup_logger
-from api.error_utilities import VideoTranscriptError
+from app.features.dynamo.tools import summarize_transcript, generate_flashcards
+from app.services.logger import setup_logger
+from app.api.error_utilities import VideoTranscriptError
 
 logger = setup_logger(__name__)
 

--- a/app/features/dynamo/tools.py
+++ b/app/features/dynamo/tools.py
@@ -5,9 +5,9 @@ from langchain_google_genai import GoogleGenerativeAI
 from langchain_core.output_parsers import JsonOutputParser
 from langchain.chains.summarize import load_summarize_chain
 from langchain_core.pydantic_v1 import BaseModel, Field
-from api.error_utilities import VideoTranscriptError
+from app.api.error_utilities import VideoTranscriptError
 from fastapi import HTTPException
-from services.logger import setup_logger
+from app.services.logger import setup_logger
 import os
 
 

--- a/app/features/quizzify/core.py
+++ b/app/features/quizzify/core.py
@@ -1,8 +1,8 @@
-from services.tool_registry import ToolFile
-from services.logger import setup_logger
-from features.quizzify.tools import RAGpipeline
-from features.quizzify.tools import QuizBuilder
-from api.error_utilities import LoaderError, ToolExecutorError
+from app.services.tool_registry import ToolFile
+from app.services.logger import setup_logger
+from app.features.quizzify.tools import RAGpipeline
+from app.features.quizzify.tools import QuizBuilder
+from app.api.error_utilities import LoaderError, ToolExecutorError
 
 logger = setup_logger()
 

--- a/app/features/quizzify/tests/test_loaders.py
+++ b/app/features/quizzify/tests/test_loaders.py
@@ -1,7 +1,7 @@
 import pytest
 from unittest.mock import patch, MagicMock
-from services.tool_registry import ToolFile
-from features.quizzify.tools import URLLoader, BytesFilePDFLoader, Document  # Adjust the import path as necessary
+from app.services.tool_registry import ToolFile
+from app.features.quizzify.tools import URLLoader, BytesFilePDFLoader, Document  # Adjust the import path as necessary
 
 @pytest.fixture
 def pdf_loader():

--- a/app/features/quizzify/tools.py
+++ b/app/features/quizzify/tools.py
@@ -18,9 +18,9 @@ from langchain_core.pydantic_v1 import BaseModel, Field
 from langchain_google_genai import GoogleGenerativeAI
 from langchain_google_genai import GoogleGenerativeAIEmbeddings
 
-from services.logger import setup_logger
-from services.tool_registry import ToolFile
-from api.error_utilities import LoaderError
+from app.services.logger import setup_logger
+from app.services.tool_registry import ToolFile
+from app.api.error_utilities import LoaderError
 
 relative_path = "features/quzzify"
 

--- a/app/main.py
+++ b/app/main.py
@@ -3,9 +3,9 @@ from fastapi.responses import JSONResponse
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from contextlib import asynccontextmanager
-from api.router import router
-from services.logger import setup_logger
-from api.error_utilities import ErrorResponse
+from app.api.router import router
+from app.services.logger import setup_logger
+from app.api.error_utilities import ErrorResponse
 
 import os
 from dotenv import load_dotenv

--- a/app/main.py
+++ b/app/main.py
@@ -8,9 +8,9 @@ from app.services.logger import setup_logger
 from app.api.error_utilities import ErrorResponse
 
 import os
-from dotenv import load_dotenv
+from dotenv import load_dotenv, find_dotenv
 
-load_dotenv()
+load_dotenv(find_dotenv())
 
 logger = setup_logger(__name__)
 

--- a/app/services/schemas.py
+++ b/app/services/schemas.py
@@ -1,7 +1,7 @@
 from pydantic import BaseModel
 from typing import Optional, List, Any
 from enum import Enum
-from services.tool_registry import BaseTool
+from app.services.tool_registry import BaseTool
 
 
 class User(BaseModel):

--- a/app/services/tool_registry.py
+++ b/app/services/tool_registry.py
@@ -1,7 +1,7 @@
 from pydantic import BaseModel
-from services.logger import setup_logger
+from app.services.logger import setup_logger
 from typing import List, Any, Optional, Dict
-from api.error_utilities import InputValidationError
+from app.api.error_utilities import InputValidationError
 
 logger = setup_logger(__name__)
 

--- a/load_env.sh
+++ b/load_env.sh
@@ -5,6 +5,7 @@ while IFS== read -r key value; do
   # Skip blank lines and comments starting with #
   if [[ -n "$key" && ! "$key" =~ ^[[:space:]]*# ]]; then
     # Export the variable (makes it available to the script)
+    echo "export $key=$value"
     export "$key=$value"
   fi
 done < ".env"

--- a/local-start.sh
+++ b/local-start.sh
@@ -1,13 +1,14 @@
 source ./load_env.sh
 
-echo "Starting local server"
+echo "Starting local server\n"
 
 export LANGCHAIN_TRACING_V2=true
 export LANGCHAIN_ENDPOINT="https://api.smith.langchain.com"
 export LANGCHAIN_API_KEY=$LANGSMITH_API_KEY
 export LANGCHAIN_PROJECT=$LANGSMITH_PROJECT
+export GOOGLE_API_KEY=$GOOGLE_API_KEY
 
-export GOOGLE_APPLICATION_CREDENTIALS=$(pwd)/app/local-auth.json
+#export GOOGLE_APPLICATION_CREDENTIALS=$(pwd)/app/local-auth.json
 export ENV_TYPE=dev
 export PROJECT_ID=$GCP_PROJECT_ID
 export PYTHONPATH=$(pwd)/app
@@ -19,5 +20,6 @@ echo "LANGCHAIN_API_KEY: $LANGCHAIN_API_KEY"
 echo "LANGCHAIN_PROJECT: $LANGCHAIN_PROJECT"
 echo "ENV_TYPE: $ENV_TYPE"
 echo "PROJECT_ID: $PROJECT_ID"
+echo "GOOGLE_API_KEY: $GOOGLE_API_KEY"
 
 fastapi dev app/main.py


### PR DESCRIPTION
- Update Dockerfile commands to copy into a `/code` rather than `/app` for semantics
- Copy the requirements.txt file and use Docker cache for faster image building
- Resolve module import after using `fastapi run main.py` due to relative import error